### PR TITLE
Cronjob Duplicate Fix

### DIFF
--- a/ssl-apache.sh
+++ b/ssl-apache.sh
@@ -324,6 +324,5 @@ sudo sed -i 's/((/$((/' /var/www/html/kill.sh
 
 (crontab -l | grep . ; echo -e "* * * * * /var/www/html/kill.sh") | crontab -
 (crontab -l ; echo "* * * * * wget -q -O /dev/null 'https://${domain}:$portssl/fixer/exp' > /dev/null 2>&1") | crontab -
-(crontab -l | grep . ; echo -e "* * * * * /var/www/html/dropbear.sh") | crontab -
 clear
 printf "\nHTTPS Address : https://${domain}:$portssl/login \n"

--- a/ssl.sh
+++ b/ssl.sh
@@ -151,8 +151,5 @@ ENDOFFILE
 (crontab -l | grep . ; echo -e "* * * * * /var/www/html/other.sh") | crontab -
 (crontab -l | grep . ; echo -e "0 */1 * * * /var/www/html/killlog.sh") | crontab -
 (crontab -l ; echo "* * * * * wget -q -O /dev/null 'https://${domain}:$def_port/fixer/exp' > /dev/null 2>&1") | crontab -
-if dpkg -l | grep -q dropbear; then
-(crontab -l | grep . ; echo -e "* * * * * /var/www/html/dropbear.sh") | crontab -
-fi
 clear
 printf "\nHTTPS Address : https://${domain}:$def_port/login \n"


### PR DESCRIPTION
if the user installs dropbear from xpanel.sh, "* * * * * /var/www/html/dropbear.sh" will be added twice to crontab, because it's defined in dropbear installation once.